### PR TITLE
Use overflow:auto

### DIFF
--- a/_scss/_highlights.scss
+++ b/_scss/_highlights.scss
@@ -7,7 +7,7 @@
   -webkit-box-shadow: 3px 3px rgba(0,0,0,0.1);
   box-shadow: 3px 3px rgba(0,0,0,0.1);
   margin: 20px 0 20px 0;
-  overflow: scroll;
+  overflow: auto;
 }
 
 code {


### PR DESCRIPTION
<b>Because it looks much better as overflow:auto displays scrollbar(s) only when needed.</b>

<b>Before:</b> (overflow:scroll)
![before](https://cloud.githubusercontent.com/assets/3154126/6499628/d0812858-c324-11e4-98c2-59a39b67ebc2.png)

<b>After:</b> (overflow:auto)
![after](https://cloud.githubusercontent.com/assets/3154126/6499630/dab908f4-c324-11e4-9a23-5a2e5ae1b7cf.png)
